### PR TITLE
fix: add warning for Gmail SMTP username mismatch and fallback to fromEmail

### DIFF
--- a/app/src/main/java/com/mikoz/sms2email/MainActivity.kt
+++ b/app/src/main/java/com/mikoz/sms2email/MainActivity.kt
@@ -436,6 +436,18 @@ fun MailPreferencesScreen(
           singleLine = true,
       )
 
+      if (config.smtpHost.contains("gmail", ignoreCase = true) &&
+          smtpUserState.value.isNotBlank() &&
+          smtpUserState.value != fromEmailState.value) {
+        Text(
+            text =
+                "Warning: For Gmail, the SMTP username should be your full email address (same as From Email Address).",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+      }
+
       OutlinedTextField(
           value = smtpPasswordState.value,
           onValueChange = { smtpPasswordState.value = it },


### PR DESCRIPTION
Following the suggestion from #106, this PR takes a less intrusive approach — instead of hiding the SMTP Username field for Gmail users, it **adds a warning** when the username doesn't match the From Email Address.

**Problem:** Users often enter random text (like an app name) as the SMTP Username, causing `535-5.7.8 Username and Password not accepted` errors. For Gmail, the username must always be the full email address.

**Changes:**
- **Warning:** Shows a red warning below the SMTP Username field when the host is Gmail and the username doesn't match the From Email Address.
- **Fallback:** If SMTP Username is left blank, it automatically falls back to the From Email Address for authentication.

This follows the same warning pattern already used for port/encryption mismatches.